### PR TITLE
Fix vctrl argument bugs

### DIFF
--- a/visualinux/cmd/vctrl.py
+++ b/visualinux/cmd/vctrl.py
@@ -122,7 +122,7 @@ class VCtrlHandler:
         print(f'+ vctrl remove id={args.id}')
         data = {
             'command': 'REMOVE',
-            'id': args.id
+            'wKey': args.id
         }
         core.send(data)
 

--- a/visualinux/cmd/vctrl.py
+++ b/visualinux/cmd/vctrl.py
@@ -53,7 +53,7 @@ class VCtrlHandler:
         chat_parser.add_argument('message', type=str, nargs='+', help='Message sent to LLM')
         chat_parser.set_defaults(handle=cls.__invoke_chat)
 
-        args = parser.parse_args(re.split(r'\s+', arg))
+        args = parser.parse_args(re.split(r'[^\S\r\n]+', arg))
 
         if hasattr(args, 'handle'):
             args.handle(args)
@@ -128,11 +128,12 @@ class VCtrlHandler:
 
     @classmethod
     def __invoke_apply(cls, args):
-        print(f'+ vctrl apply id={args.id} vql={args.vql}')
+        print(f'+ vctrl apply id={args.id} vql={args.viewql}')
+        vqlCode = " ".join(args.viewql)
         data = {
             'command': 'APPLY',
-            'id': args.id,
-            'vql': args.vql
+            'wKey': args.id,
+            'vqlCode': vqlCode
         }
         core.send(data)
 


### PR DESCRIPTION
1.  rename some JSON keys in `__invoke_remove` and `__invoke_apply` in order to match command args in `GlobalStateAction`.
2.  join the words split from ViewQL statements into a whole.