### PR TITLE
Fix incorrect make targets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ This repo provides three different ways to startup Visualinux. You can choose yo
 Visualinux is designed to be an auxiliary tool and does not interfere with the typical gdb workflow. Thus, you can start the gdb host and stub in separate terminals as usual:
 
 ```sh
-make start    # in terminal 1
-make attach   # in terminal 2
+make gdb-start    # in terminal 1
+make gdb-attach   # in terminal 2
 ```
 
 And start the visualizer app in another terminal:


### PR DESCRIPTION
README.md refers to `make start` and `make attach`, but the actual Makefile targets are `make gdb-start` and `make gdb-attach`.

Update the documentation to match the real Makefile targets.