### PR TITLE
gitignore: fix Python cache dirs being re-exposed by local !* rules

### DIFF
--- a/page/.gitignore
+++ b/page/.gitignore
@@ -1,5 +1,18 @@
 !*
 
+# Keep Python cache/bytecode ignored inside page/.
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.hypothesis/
+.tox/
+.nox/
+.coverage
+.venv/
+venv/
+
 # Logs
 logs
 *.log

--- a/scripts/dev/viewcl-lang-extension/.gitignore
+++ b/scripts/dev/viewcl-lang-extension/.gitignore
@@ -1,4 +1,18 @@
 !*
+
+# Keep Python cache/bytecode ignored inside this subproject.
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.hypothesis/
+.tox/
+.nox/
+.coverage
+.venv/
+venv/
+
 node_modules/
 out/
 .vscode-test

--- a/visualizer/.gitignore
+++ b/visualizer/.gitignore
@@ -1,5 +1,18 @@
 !*
 
+# Keep Python cache/bytecode ignored inside visualizer/.
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.hypothesis/
+.tox/
+.nox/
+.coverage
+.venv/
+venv/
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Subdirectories that use a local `!*` re-include pattern (page/, visualizer/, scripts/dev/viewcl-lang-extension/) were inadvertently un-ignoring Python cache artifacts that the root .gitignore intended to suppress.

Add explicit ignore rules right after each `!*` in those files:

  __pycache__/
  *.py[cod]
  .pytest_cache/
  .mypy_cache/
  .ruff_cache/
  .hypothesis/
  .tox/
  .nox/
  .coverage
  .venv/
  venv/